### PR TITLE
Move OpenSSL iv_len conditional gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source 'https://rubygems.org'
+
+require 'openssl'
+unless OpenSSL::Cipher.new('aes-256-gcm').respond_to?(:iv_len=)
+  gem 'aes256gcm_decrypt', :git => 'https://github.com/clearhaus/aes256gcm_decrypt'
+end
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
 source 'https://rubygems.org'
-
-require 'openssl'
-unless OpenSSL::Cipher.new('aes-256-gcm').respond_to?(:iv_len=)
-  gem 'aes256gcm_decrypt', :git => 'https://github.com/clearhaus/aes256gcm_decrypt'
-end
-
 gemspec

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -8,11 +8,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'dry-validation'
 
-  require 'openssl'
-  unless OpenSSL::Cipher.new('aes-256-gcm').respond_to?(:iv_len=)
-    s.add_runtime_dependency 'aes256gcm_decrypt', git: 'https://github.com/clearhaus/aes256gcm_decrypt'
-  end
-
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'pry', '~> 0.11'
 end

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -8,6 +8,11 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'dry-validation'
 
+  require 'openssl'
+  unless OpenSSL::Cipher.new('aes-256-gcm').respond_to?(:iv_len=)
+    s.add_runtime_dependency 'aes256gcm_decrypt'
+  end
+
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'pry', '~> 0.11'
 end


### PR DESCRIPTION
Fixes this issue on Debian Stretch:

```
root@ad648e4d0b64:/from-host# bundle install
[...]
[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `pedicel.gemspec`: Illformed requirement [{:git=>"https://github.com/clearhaus/aes256gcm_decrypt"}]. Bundler cannot continue.

 #  from /from-host/pedicel.gemspec:13
 #  -------------------------------------------
 #    unless OpenSSL::Cipher.new('aes-256-gcm').respond_to?(:iv_len=)
 >      s.add_runtime_dependency 'aes256gcm_decrypt', git: 'https://github.com/clearhaus/aes256gcm_decrypt'
 #    end
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /from-host/Gemfile:2
 #  -------------------------------------------
 #  source 'https://rubygems.org'
 >  gemspec
 #  -------------------------------------------
```

It seems e.g. a git path is not supported in a .gemspec file:

https://stackoverflow.com/questions/19494295/specify-git-path-in-gemspec-add-dependency-entry