### PR TITLE
CA cert as parameter

### DIFF
--- a/lib/pedicel/base.rb
+++ b/lib/pedicel/base.rb
@@ -99,7 +99,7 @@ module Pedicel
       false
     end
 
-    def verify_signature(now: Time.now)
+    def verify_signature(ca_certificate_pem: Pedicel.config[:apple_root_ca_g3_cert_pem], now: Time.now)
       raise SignatureError, 'no signature present' unless signature
 
       begin
@@ -114,7 +114,7 @@ module Pedicel
       leaf, intermediate = self.class.verify_signature_certificate_oids(signature: s)
 
       begin
-        root = OpenSSL::X509::Certificate.new(Pedicel.config[:apple_root_ca_g3_cert_pem])
+        root = OpenSSL::X509::Certificate.new(ca_certificate_pem)
       rescue => e
         raise CertificateError, "invalid root certificate: #{e.message}"
       end

--- a/lib/pedicel/ec.rb
+++ b/lib/pedicel/ec.rb
@@ -6,7 +6,8 @@ module Pedicel
       Base64.decode64(@token['header']['ephemeralPublicKey'])
     end
 
-    def decrypt(symmetric_key: nil, merchant_id: nil, certificate: nil, private_key: nil, now: Time.now)
+    def decrypt(symmetric_key: nil, merchant_id: nil, certificate: nil, private_key: nil,
+                ca_certificate_pem: Pedicel.config[:apple_root_ca_g3_cert_pem], now: Time.now)
       raise ArgumentError 'invalid argument combination' unless \
         !symmetric_key.nil? ^ ((!merchant_id.nil? ^ !certificate.nil?) && !private_key.nil?)
       # .-------------------'--------. .----------'----. .-------------''---.
@@ -24,7 +25,7 @@ module Pedicel
                                       merchant_id: merchant_id)
       end
 
-      verify_signature(now: now)
+      verify_signature(ca_certificate_pem: ca_certificate_pem, now: now)
       decrypt_aes(key: symmetric_key)
     end
 

--- a/lib/pedicel/ec.rb
+++ b/lib/pedicel/ec.rb
@@ -1,4 +1,4 @@
-require 'base'
+require 'pedicel/base'
 
 module Pedicel
   class EC < Base

--- a/lib/pedicel/rsa.rb
+++ b/lib/pedicel/rsa.rb
@@ -1,4 +1,4 @@
-require 'base'
+require 'pedicel/base'
 
 module Pedicel
   class RSA < Base

--- a/spec/some_spec.rb
+++ b/spec/some_spec.rb
@@ -24,7 +24,7 @@ describe 'basic test' do
 
   it 'works' do
     backend = PedicelPay::Backend.new
-    Pedicel.config = Pedicel.config.merge(apple_root_ca_g3_cert_pem: backend.ca_cert.to_pem)
+    Pedicel.config.merge!(apple_root_ca_g3_cert_pem: backend.ca_cert.to_pem)
     merchant = PedicelPay::Merchant.new
 
     merchant_certificate = backend.sign_csr(merchant.csr)


### PR DESCRIPTION
While eating my own dog food (building `pedicel-pay`), I notice that it's handy to allow the CA certificate to be provided as a parameter, rather than setting it back and forth — for instance while writing specs.