### PR TITLE
Validate token on initialization

### DIFF
--- a/lib/pedicel/base.rb
+++ b/lib/pedicel/base.rb
@@ -1,13 +1,16 @@
 require 'openssl'
 require 'base64'
+require 'pedicel/validator'
 
 module Pedicel
   class Base
     SUPPORTED_VERSIONS = [:EC_v1].freeze
 
-    attr_accessor :config
+    attr_reader :config
 
     def initialize(token, config: Pedicel::DEFAULT_CONFIG)
+      Validator.validate_token(token)
+
       @token  = token
       @config = config
     end

--- a/spec/lib/pedicel/ec_spec.rb
+++ b/spec/lib/pedicel/ec_spec.rb
@@ -108,7 +108,7 @@ describe 'Pedicel::EC' do
 
     it 'errs if application_data has been changed' do
       backend.encrypt_and_sign(token, recipient: client)
-      token.header.data_hash = OpenSSL::Digest::SHA256.new('foobar').digest
+      token.header.data_hash = OpenSSL::Digest::SHA256.new('foobar').hexdigest
       pedicel = Pedicel::EC.new(token.to_hash)
 
       expect{pedicel.validate_signature(signature: signature, leaf: backend.leaf_certificate)}.to raise_error(Pedicel::SignatureError, /signature.*not match.* message/)

--- a/spec/lib/pedicel/ec_spec.rb
+++ b/spec/lib/pedicel/ec_spec.rb
@@ -22,8 +22,8 @@ describe 'Pedicel::EC' do
 
       backend.encrypt_and_sign(token, recipient: client, shared_secret: ss, ephemeral_pubkey: epk)
 
-      pedicel = Pedicel::EC.new(token.to_hash)
-      pedicel.config = Pedicel::DEFAULT_CONFIG.merge(trusted_ca_pem: backend.ca_certificate.to_pem)
+      config = Pedicel::DEFAULT_CONFIG.merge(trusted_ca_pem: backend.ca_certificate.to_pem)
+      pedicel = Pedicel::EC.new(token.to_hash, config: config)
 
       symmetric_key = Pedicel::EC.symmetric_key(
         shared_secret: ss,


### PR DESCRIPTION
I think the user shouldn't validate the token explicitly. @mt-clearhaus WDYT?

Specs ...