### PR TITLE
Use symbols in improve validator

### DIFF
--- a/lib/pedicel/base.rb
+++ b/lib/pedicel/base.rb
@@ -9,36 +9,37 @@ module Pedicel
     attr_reader :config
 
     def initialize(token, config: Pedicel::DEFAULT_CONFIG)
-      Validator::Token.new(token).validate
+      validation = Validator::Token.new(token)
+      validation.validate
 
-      @token  = token
+      @token  = validation.output
       @config = config
     end
 
     def version
-      @token['version']&.to_sym
+      @token[:version].to_sym
     end
 
     def encrypted_data
-      return nil unless @token['data']
+      return nil unless @token[:data]
 
-      Base64.decode64(@token['data'])
+      Base64.decode64(@token[:data])
     end
 
     def signature
-      return nil unless @token['signature']
+      return nil unless @token[:signature]
 
-      Base64.decode64(@token['signature'])
+      Base64.decode64(@token[:signature])
     end
 
     def transaction_id
-      [@token['header']['transactionId']].pack('H*')
+      [@token[:header][:transactionId]].pack('H*')
     end
 
     def application_data
-      return nil unless @token['header']['applicationData']
+      return nil unless @token[:header][:applicationData]
 
-      [@token['header']['applicationData']].pack('H*')
+      [@token[:header][:applicationData]].pack('H*')
     end
 
     def private_key_class

--- a/lib/pedicel/base.rb
+++ b/lib/pedicel/base.rb
@@ -66,8 +66,7 @@ module Pedicel
       end
     end
 
-    private
-    def decrypt_aes_openssl(key)
+    private def decrypt_aes_openssl(key)
       cipher = OpenSSL::Cipher.new(symmetric_algorithm)
       cipher.decrypt
 
@@ -94,14 +93,13 @@ module Pedicel
       raise Pedicel::AesKeyError, 'wrong key'
     end
 
-    def decrypt_aes_gem(key)
+    private def decrypt_aes_gem(key)
       require 'aes256gcm_decrypt'
 
       Aes256GcmDecrypt.decrypt(encrypted_data, key)
     rescue Aes256GcmDecrypt::Error => e
       raise Pedicel::AesKeyError, "decryption failed: #{e}"
     end
-    public
 
     def valid_signature?(now: Time.now)
       !!verify_signature(now: now)

--- a/lib/pedicel/ec.rb
+++ b/lib/pedicel/ec.rb
@@ -3,7 +3,7 @@ require 'pedicel/base'
 module Pedicel
   class EC < Base
     def ephemeral_public_key
-      Base64.decode64(@token['header']['ephemeralPublicKey'])
+      Base64.decode64(@token[:header][:ephemeralPublicKey])
     end
 
     def decrypt(symmetric_key: nil, merchant_id: nil, certificate: nil, private_key: nil,

--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -67,17 +67,6 @@ module Pedicel
     end
 
     TokenHeaderSchema = Dry::Validation.Schema(BaseSchema) do
-      configure do
-        # NOTE: This option removes/sanitizes hash element not mentioned/tested.
-        # Hurray for good documentation.
-        config.input_processor = :json
-
-        # In theory, I would guess that :strict below would cause a failure if
-        # untested keys were encountered, however this appears to not be the
-        # case. Anyways, it's (of course) not documented.
-        # config.hash_type = :strict
-      end
-
       optional(:applicationData).filled(:str?, :hex?, :hex_sha256?)
 
       optional(:ephemeralPublicKey).filled(:str?, :base64?, :ec_public_key?)

--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -145,6 +145,8 @@ module Pedicel
     class Error < StandardError; end
 
     module InstanceMethods
+      attr_reader :output
+
       def validate
         @validation ||= @schema.call(@input)
 
@@ -154,8 +156,6 @@ module Pedicel
 
         raise Error, "validation error: #{@validation.errors.keys.join(', ')}"
       end
-
-      attr_reader :output
 
       def valid?
         validate

--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -59,7 +59,7 @@ module Pedicel
       predicate(:iso4217_numeric?) { |x| match_b.(x, /\A[0-9]{3}\z/) }
     end
 
-    class BaseSchema < Dry::Validation::Schema
+    class BaseSchema < Dry::Validation::Schema::JSON
       predicates(Predicates)
       def self.messages
         super.merge(en: { errors: Predicates::CUSTOM_PREDICATE_ERRORS })
@@ -94,8 +94,6 @@ module Pedicel
     end
 
     TokenSchema = Dry::Validation.Schema(BaseSchema) do
-      configure { config.input_processor = :json }
-
       required(:data).filled(:str?, :base64?)
 
       required(:header).schema(TokenHeaderSchema)
@@ -106,50 +104,50 @@ module Pedicel
     end
 
     TokenDataPaymentDataSchema = Dry::Validation.Schema(BaseSchema) do
-      optional('onlinePaymentCryptogram').filled(:str?, :base64?)
-      optional('eciIndicator').filled(:str?, :eci?)
+      optional(:onlinePaymentCryptogram).filled(:str?, :base64?)
+      optional(:eciIndicator).filled(:str?, :eci?)
 
-      optional('emvData').filled(:str?, :base64?)
-      optional('encryptedPINData').filled(:str?, :hex?)
+      optional(:emvData).filled(:str?, :base64?)
+      optional(:encryptedPINData).filled(:str?, :hex?)
     end
 
     TokenDataSchema = Dry::Validation.Schema(BaseSchema) do
-      required('applicationPrimaryAccountNumber').filled(:str?, :pan?)
+      required(:applicationPrimaryAccountNumber).filled(:str?, :pan?)
 
-      required('applicationExpirationDate').filled(:str?, :yymmdd?)
+      required(:applicationExpirationDate).filled(:str?, :yymmdd?)
 
-      required('currencyCode').filled(:str?, :iso4217_numeric?)
+      required(:currencyCode).filled(:str?, :iso4217_numeric?)
 
-      required('transactionAmount').filled(:int?)
+      required(:transactionAmount).filled(:int?)
 
-      optional('cardholderName').filled(:str?)
+      optional(:cardholderName).filled(:str?)
 
-      required('deviceManufacturerIdentifier').filled(:str?, :hex?)
+      required(:deviceManufacturerIdentifier).filled(:str?, :hex?)
 
-      required('paymentDataType').filled(:str?, included_in?: %w[3DSecure EMV])
+      required(:paymentDataType).filled(:str?, included_in?: %w[3DSecure EMV])
 
-      required('paymentData').schema(TokenDataPaymentDataSchema)
+      required(:paymentData).schema(TokenDataPaymentDataSchema)
 
-      rule('when paymentDataType is 3DSecure, onlinePaymentCryptogram': ['paymentDataType', ['paymentData', 'onlinePaymentCryptogram']]) do |type, cryptogram|
+      rule('when paymentDataType is 3DSecure, onlinePaymentCryptogram': [:paymentDataType, [:paymentData, :onlinePaymentCryptogram]]) do |type, cryptogram|
         type.eql?('3DSecure') > cryptogram.filled?
       end
-      rule('when paymentDataType is 3DSecure, emvData': ['paymentDataType', ['paymentData', 'emvData']]) do |type, emv|
+      rule('when paymentDataType is 3DSecure, emvData': [:paymentDataType, [:paymentData, :emvData]]) do |type, emv|
         type.eql?('3DSecure') > emv.none?
       end
-      rule('when paymentDataType is 3DSecure, encryptedPINData': ['paymentDataType', ['paymentData', 'encryptedPINData']]) do |type, pin|
+      rule('when paymentDataType is 3DSecure, encryptedPINData': [:paymentDataType, [:paymentData, :encryptedPINData]]) do |type, pin|
         type.eql?('3DSecure') > pin.none?
       end
 
-      rule('when paymentDataType is EMV, onlinePaymentCryptogram': ['paymentDataType', ['paymentData', 'onlinePaymentCryptogram']]) do |type, cryptogram|
+      rule('when paymentDataType is EMV, onlinePaymentCryptogram': [:paymentDataType, [:paymentData, :onlinePaymentCryptogram]]) do |type, cryptogram|
         type.eql?('EMV') > cryptogram.none?
       end
-      rule('when paymentDataType is EMV, eciIndicator': ['paymentDataType', ['paymentData', 'eciIndicator']]) do |type, eci|
+      rule('when paymentDataType is EMV, eciIndicator': [:paymentDataType, [:paymentData, :eciIndicator]]) do |type, eci|
         type.eql?('EMV') > eci.none?
       end
-      rule('when paymentDataType is EMV, emvData': ['paymentDataType', ['paymentData', 'emvData']]) do |type, emv|
+      rule('when paymentDataType is EMV, emvData': [:paymentDataType, [:paymentData, :emvData]]) do |type, emv|
         type.eql?('EMV') > emv.filled?
       end
-      rule('when paymentDataType is EMV, encryptedPINData': ['paymentDataType', ['paymentData', 'encryptedPINData']]) do |type, pin|
+      rule('when paymentDataType is EMV, encryptedPINData': [:paymentDataType, [:paymentData, :encryptedPINData]]) do |type, pin|
         type.eql?('EMV') > pin.filled?
       end
 

--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -148,10 +148,14 @@ module Pedicel
       def validate
         @validation ||= @schema.call(@input)
 
+        @output = @validation.output
+
         return true if @validation.success?
 
         raise Error, "validation error: #{@validation.errors.keys.join(', ')}"
       end
+
+      attr_reader :output
 
       def valid?
         validate

--- a/spec/lib/pedicel/validator/token_data_payment_data_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_data_payment_data_schema_spec.rb
@@ -4,15 +4,15 @@ require 'lib/pedicel/validator/helper'
 
 describe 'Pedicel::Validator::TokenDataPaymentDataSchema' do
   let(:tdpds) { Pedicel::Validator::TokenDataPaymentDataSchema }
-  let(:token_data_payment_data_h) { JSON.parse(token.unencrypted_data.to_hash.to_json)['paymentData'] }
+  let(:token_data_payment_data_h) { JSON.parse(token.unencrypted_data.to_hash.to_json, symbolize_names: true)[:paymentData] }
   subject { token_data_payment_data_h }
 
-  %w(
-      onlinePaymentCryptogram
-      eciIndicator
-      emvData
-      encryptedPINData
-  ).each do |payment_data_string_key|
+  %i[
+    onlinePaymentCryptogram
+    eciIndicator
+    emvData
+    encryptedPINData
+  ].each do |payment_data_string_key|
     it "errs when #{payment_data_string_key} is not a string" do
       token_data_payment_data_h[payment_data_string_key] = 42
 
@@ -22,20 +22,20 @@ describe 'Pedicel::Validator::TokenDataPaymentDataSchema' do
 
   context 'onlinePaymentCryptogram' do
     it 'may be present' do
-      token_data_payment_data_h['onlinePaymentCryptogram'] = 'validBase64='
+      token_data_payment_data_h[:onlinePaymentCryptogram] = 'validBase64='
       is_expected.to satisfy_schema(tdpds)
     end
 
     it 'may be absent' do
-      token_data_payment_data_h.delete('onlinePaymentCryptogram')
+      token_data_payment_data_h.delete(:onlinePaymentCryptogram)
       is_expected.to satisfy_schema(tdpds)
     end
 
     it 'errs when not Base64' do
-      %w(% fooo= f===).each do |invalid_value|
-        token_data_payment_data_h['onlinePaymentCryptogram'] = invalid_value
+      %w[% fooo= f===].each do |invalid_value|
+        token_data_payment_data_h[:onlinePaymentCryptogram] = invalid_value
 
-        is_expected.to dissatisfy_schema(tdpds, 'onlinePaymentCryptogram' => ['must be Base64'])
+        is_expected.to dissatisfy_schema(tdpds, onlinePaymentCryptogram: ['must be Base64'])
       end
     end
   end
@@ -52,10 +52,10 @@ describe 'Pedicel::Validator::TokenDataPaymentDataSchema' do
     end
 
     it 'errs when invalid' do
-      %w(1 123 1A).each do |invalid_value|
-        token_data_payment_data_h['eciIndicator'] = invalid_value
+      %w[1 123 1A].each do |invalid_value|
+        token_data_payment_data_h[:eciIndicator] = invalid_value
 
-        is_expected.to dissatisfy_schema(tdpds, 'eciIndicator' => ['must be an ECI'])
+        is_expected.to dissatisfy_schema(tdpds, eciIndicator: ['must be an ECI'])
       end
     end
   end
@@ -72,29 +72,29 @@ describe 'Pedicel::Validator::TokenDataPaymentDataSchema' do
     end
 
     it 'errs when not Base64' do
-      %w(% fooo= f===).each do |invalid_value|
-        token_data_payment_data_h['emvData'] = invalid_value
+      %w[% fooo= f===].each do |invalid_value|
+        token_data_payment_data_h[:emvData] = invalid_value
 
-        is_expected.to dissatisfy_schema(tdpds, 'emvData' => ['must be Base64'])
+        is_expected.to dissatisfy_schema(tdpds, emvData: ['must be Base64'])
       end
     end
   end
 
   context 'encryptedPINData' do
     it 'may be present' do
-      token_data_payment_data_h['encryptedPINData'] = 'a1b2c3d4e5f6'
+      token_data_payment_data_h[:encryptedPINData] = 'a1b2c3d4e5f6'
       is_expected.to satisfy_schema(tdpds)
     end
 
     it 'may be absent' do
-      token_data_payment_data_h.delete('encryptedPINData')
+      token_data_payment_data_h.delete(:encryptedPINData)
       is_expected.to satisfy_schema(tdpds)
     end
 
     it 'errs when not hex' do
-      %w(42-42 42Z).each do |invalid_value|
-        token_data_payment_data_h['encryptedPINData'] = invalid_value
-        is_expected.to dissatisfy_schema(tdpds, 'encryptedPINData' => ['must be hex'])
+      %w[42-42 42Z].each do |invalid_value|
+        token_data_payment_data_h[:encryptedPINData] = invalid_value
+        is_expected.to dissatisfy_schema(tdpds, encryptedPINData: ['must be hex'])
       end
     end
   end

--- a/spec/lib/pedicel/validator/token_data_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_data_schema_spec.rb
@@ -4,7 +4,16 @@ require 'lib/pedicel/validator/helper'
 
 describe 'Pedicel::Validator::TokenDataSchema' do
   let(:tds) { Pedicel::Validator::TokenDataSchema }
-  let(:token_data_h) { JSON.parse(token.unencrypted_data.to_hash.to_json, symbolize_names: true) }
+
+  it 'is happy about a hash with string keys' do
+    expect(JSON.parse(token.unencrypted_data.to_json, symbolize_names: false)).to satisfy_schema(tds)
+  end
+
+  it 'is happy about a hash with symbolic keys' do
+    expect(JSON.parse(token.unencrypted_data.to_json, symbolize_names: true)).to satisfy_schema(tds)
+  end
+
+  let(:token_data_h) { token.unencrypted_data.to_hash }
   subject { token_data_h }
 
   context 'wrong data' do

--- a/spec/lib/pedicel/validator/token_data_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_data_schema_spec.rb
@@ -4,11 +4,11 @@ require 'lib/pedicel/validator/helper'
 
 describe 'Pedicel::Validator::TokenDataSchema' do
   let(:tds) { Pedicel::Validator::TokenDataSchema }
-  let(:token_data_h) { JSON.parse(token.unencrypted_data.to_hash.to_json) }
+  let(:token_data_h) { JSON.parse(token.unencrypted_data.to_hash.to_json, symbolize_names: true) }
   subject { token_data_h }
 
   context 'wrong data' do
-    %w(
+    %i[
       applicationPrimaryAccountNumber
       applicationExpirationDate
       currencyCode
@@ -16,21 +16,21 @@ describe 'Pedicel::Validator::TokenDataSchema' do
       deviceManufacturerIdentifier
       paymentDataType
       paymentData
-    ).each do |required_key|
+    ].each do |required_key|
       it "errs when #{required_key} is missing" do
         token_data_h.delete(required_key)
         is_expected.to dissatisfy_schema(tds, required_key => ['is missing'])
       end
     end
 
-    %w(
+    %i[
       applicationPrimaryAccountNumber
       applicationExpirationDate
       currencyCode
       cardholderName
       deviceManufacturerIdentifier
       paymentDataType
-    ).each do |string_key|
+    ].each do |string_key|
       it "errs when #{string_key} is not a string" do
         token_data_h.merge!(string_key => 42)
         is_expected.to dissatisfy_schema(tds, string_key => ['must be a string'])
@@ -38,28 +38,28 @@ describe 'Pedicel::Validator::TokenDataSchema' do
     end
 
     it 'errs when applicationPrimaryAccountNumber is not a PAN' do
-      %w(
+      %w[
         0123123412341234
         1234567890
         12345678901234567890
         1234A23412341234
-      ).each do |invalid_value|
-        token_data_h['applicationPrimaryAccountNumber'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'applicationPrimaryAccountNumber' => ['must be a pan'])
+      ].each do |invalid_value|
+        token_data_h[:applicationPrimaryAccountNumber] = invalid_value
+        is_expected.to dissatisfy_schema(tds, applicationPrimaryAccountNumber: ['must be a pan'])
       end
     end
 
     it 'errs when applicationExpirationDate is not a date' do
-      %w(12345 1234567 1A3456).each do |invalid_value|
-        token_data_h['applicationExpirationDate'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'applicationExpirationDate' => ['must be formatted YYMMDD'])
+      %w[12345 1234567 1A3456].each do |invalid_value|
+        token_data_h[:applicationExpirationDate] = invalid_value
+        is_expected.to dissatisfy_schema(tds, applicationExpirationDate: ['must be formatted YYMMDD'])
       end
     end
 
     it 'errs when currencyCode is not a currency code' do
-      %w(11 11A 1111).each do |invalid_value|
-        token_data_h['currencyCode'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'currencyCode' => ['must be an ISO 4217 numeric code'])
+      %w[11 11A 1111].each do |invalid_value|
+        token_data_h[:currencyCode] = invalid_value
+        is_expected.to dissatisfy_schema(tds, currencyCode: ['must be an ISO 4217 numeric code'])
       end
     end
 
@@ -72,22 +72,22 @@ describe 'Pedicel::Validator::TokenDataSchema' do
         { 'abc' => 42 },
         true,
       ].each do |invalid_value|
-        token_data_h['transactionAmount'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'transactionAmount' => ['must be an integer'])
+        token_data_h[:transactionAmount] = invalid_value
+        is_expected.to dissatisfy_schema(tds, transactionAmount: ['must be an integer'])
       end
     end
 
     it 'errs when deviceManufacturerIdentifier is not hex' do
-      %w(42-42 42Z).each do |invalid_value|
-        token_data_h['deviceManufacturerIdentifier'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'deviceManufacturerIdentifier' => ['must be hex'])
+      %w[42-42 42Z].each do |invalid_value|
+        token_data_h[:deviceManufacturerIdentifier] = invalid_value
+        is_expected.to dissatisfy_schema(tds, deviceManufacturerIdentifier: ['must be hex'])
       end
     end
 
     it 'errs when paymentDataType is unsupported' do
-      %w(3dsecure emv 3D Secure 3DSecure2 EMVCo).each do |invalid_value|
-        token_data_h['paymentDataType'] = invalid_value
-        is_expected.to dissatisfy_schema(tds, 'paymentDataType' => ['must be one of: 3DSecure, EMV'])
+      %w[3dsecure emv 3D Secure 3DSecure2 EMVCo].each do |invalid_value|
+        token_data_h[:paymentDataType] = invalid_value
+        is_expected.to dissatisfy_schema(tds, paymentDataType: ['must be one of: 3DSecure, EMV'])
       end
     end
 
@@ -97,33 +97,33 @@ describe 'Pedicel::Validator::TokenDataSchema' do
       end
 
       it 'errs when onlinePaymentCryptogram is missing' do
-        token_data_h['paymentDataType'] = '3DSecure'
-        token_data_h['paymentData'].delete('onlinePaymentCryptogram')
+        token_data_h[:paymentDataType] = '3DSecure'
+        token_data_h[:paymentData].delete(:onlinePaymentCryptogram)
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is 3DSecure, onlinePaymentCryptogram': ['must be filled'])
       end
 
       it 'errs when emvData is present' do
-        token_data_h['paymentDataType'] = '3DSecure'
-        token_data_h['paymentData']['emvData'] = Base64.strict_encode64('EMV payment structure')
+        token_data_h[:paymentDataType] = '3DSecure'
+        token_data_h[:paymentData][:emvData] = Base64.strict_encode64('EMV payment structure')
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is 3DSecure, emvData': ['cannot be defined'])
       end
 
       it 'errs when encryptedPINData is present' do
-        token_data_h['paymentDataType'] = '3DSecure'
-        token_data_h['paymentData']['encryptedPINData'] = 'a1b2c3d4e5f6'
+        token_data_h[:paymentDataType] = '3DSecure'
+        token_data_h[:paymentData][:encryptedPINData] = 'a1b2c3d4e5f6'
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is 3DSecure, encryptedPINData': ['cannot be defined'])
       end
     end
 
     context 'paymentDataType is EMV' do
-      let(:orig) { JSON.parse(token.unencrypted_data.to_hash.to_json) }
+      let(:orig) { JSON.parse(token.unencrypted_data.to_hash.to_json, symbolize_names: true) }
 
       before(:each) do
-        token_data_h['paymentDataType'] = 'EMV'
-        token_data_h['paymentData'].delete('onlinePaymentCryptogram')
-        token_data_h['paymentData'].delete('eciIndicator')
-        token_data_h['paymentData']['emvData'] = Base64.strict_encode64('EMV payment structure')
-        token_data_h['paymentData']['encryptedPINData'] = 'a1b2c3d4e5f6'
+        token_data_h[:paymentDataType] = 'EMV'
+        token_data_h[:paymentData].delete(:onlinePaymentCryptogram)
+        token_data_h[:paymentData].delete(:eciIndicator)
+        token_data_h[:paymentData][:emvData] = Base64.strict_encode64('EMV payment structure')
+        token_data_h[:paymentData][:encryptedPINData] = 'a1b2c3d4e5f6'
       end
 
       it 'can be happy' do
@@ -131,22 +131,22 @@ describe 'Pedicel::Validator::TokenDataSchema' do
       end
 
       it 'errs when onlinePaymentCryptogram is present' do
-        token_data_h['paymentData']['onlinePaymentCryptogram'] = orig['paymentData']['onlinePaymentCryptogram']
+        token_data_h[:paymentData][:onlinePaymentCryptogram] = orig[:paymentData][:onlinePaymentCryptogram]
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is EMV, onlinePaymentCryptogram': ['cannot be defined'])
       end
 
       it 'errs when eciIndicator is present' do
-        token_data_h['paymentData']['eciIndicator'] = orig['paymentData']['eciIndicator']
+        token_data_h[:paymentData][:eciIndicator] = orig[:paymentData][:eciIndicator]
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is EMV, eciIndicator': ['cannot be defined'])
       end
 
       it 'errs when emvData is missing' do
-        token_data_h['paymentData'].delete('emvData')
+        token_data_h[:paymentData].delete(:emvData)
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is EMV, emvData': ['must be filled'])
       end
 
       it 'errs when encryptedPINData is missing' do
-        token_data_h['paymentData'].delete('encryptedPINData')
+        token_data_h[:paymentData].delete(:encryptedPINData)
         is_expected.to dissatisfy_schema(tds, 'when paymentDataType is EMV, encryptedPINData': ['must be filled'])
       end
     end

--- a/spec/lib/pedicel/validator/token_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_schema_spec.rb
@@ -4,6 +4,15 @@ require 'lib/pedicel/validator/helper'
 
 describe 'Pedicel::Validator::TokenSchema' do
   let(:ts) { Pedicel::Validator::TokenSchema }
+
+  it 'is happy about a hash with string keys' do
+    expect(JSON.parse(token.to_json, symbolize_names: false)).to satisfy_schema(ts)
+  end
+
+  it 'is happy about a hash with symbolic keys' do
+    expect(JSON.parse(token.to_json, symbolize_names: true)).to satisfy_schema(ts)
+  end
+
   let(:token_h) { token.to_hash }
   subject { token_h }
 


### PR DESCRIPTION
Replaced strings with symbols.

The only non-essential change is a change from parentheses to braces in symbol (`%i[..]`) arrays. Recommended by the [style guide](https://github.com/rubocop-hq/ruby-style-guide#percent-literal-braces).