### PR TITLE
Pass MID OID to .merchant_id as param rather than the entire config

### DIFF
--- a/lib/pedicel/ec.rb
+++ b/lib/pedicel/ec.rb
@@ -40,7 +40,7 @@ module Pedicel
 
       shared_secret = shared_secret(private_key: private_key)
 
-      merchant_id ||= self.class.merchant_id(certificate: certificate)
+      merchant_id ||= self.class.merchant_id(certificate: certificate, mid_oid: @config[:oid_merchant_identifier_field])
 
       self.class.symmetric_key(shared_secret: shared_secret, merchant_id: merchant_id)
     end
@@ -111,7 +111,7 @@ module Pedicel
       sha256.digest
     end
 
-    def self.merchant_id(certificate:, config: Pedicel::DEFAULT_CONFIG)
+    def self.merchant_id(certificate:, mid_oid: Pedicel::DEFAULT_CONFIG[:oid_merchant_identifier_field])
       begin
         cert = OpenSSL::X509::Certificate.new(certificate)
       rescue => e
@@ -121,7 +121,7 @@ module Pedicel
       merchant_id_hex =
         cert
         .extensions
-        .find { |x| x.oid == config[:oid_merchant_identifier_field] }
+        .find { |x| x.oid == mid_oid }
         &.value # Hex encoded Merchant ID plus perhaps extra non-hex chars.
         &.delete('^[0-9a-fA-F]') # Remove non-hex chars.
 

--- a/spec/lib/pedicel/ec_spec.rb
+++ b/spec/lib/pedicel/ec_spec.rb
@@ -253,8 +253,7 @@ describe 'Pedicel::EC' do
     end
 
     it 'errs if certificate has no merchant ID with the given OID' do
-      config = { oid_merchant_identifier_field: 'wrong oid' }
-      expect{Pedicel::EC.merchant_id(certificate: client.certificate, config: config)}.to raise_error(Pedicel::CertificateError, /no merchant identifier/)
+      expect{Pedicel::EC.merchant_id(certificate: client.certificate, mid_oid: 'wrong oid')}.to raise_error(Pedicel::CertificateError, /no merchant identifier/)
     end
   end
 end


### PR DESCRIPTION
See also #20.