### PR TITLE
Allow single digit ECI

### DIFF
--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -50,7 +50,7 @@ module Pedicel
 
       predicate(:yymmdd?) { |x| str?(x) && match_b.(x, /\A\d{6}\z/) }
 
-      predicate(:eci?) { |x| str?(x) && match_b.(x, /\A\d{2}\z/) }
+      predicate(:eci?) { |x| str?(x) && match_b.(x, /\A\d{1,2}\z/) }
 
       predicate(:ec_public_key?) { |x| base64?(x) && OpenSSL::PKey::EC.new(Base64.decode64(x)).check_key rescue false }
 

--- a/lib/pedicel/version.rb
+++ b/lib/pedicel/version.rb
@@ -1,3 +1,3 @@
 module Pedicel
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end

--- a/spec/lib/pedicel/validator/predicates_spec.rb
+++ b/spec/lib/pedicel/validator/predicates_spec.rb
@@ -140,13 +140,16 @@ describe Pedicel::Validator::Predicates do
 
     it 'is true for valid ECIs' do
       expect(eci?('05')).to be true
+      expect(eci?('5')).to be true
       expect(eci?('06')).to be true
+      expect(eci?('6')).to be true
       expect(eci?('07')).to be true
+      expect(eci?('7')).to be true
     end
 
     it 'is false for ECIs of wrong length' do
+      expect(eci?('')).to    be false
       expect(eci?('005')).to be false
-      expect(eci?('5')).to   be false
       expect(eci?(' 05')).to be false
     end
 

--- a/spec/lib/pedicel/validator/token_data_payment_data_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_data_payment_data_schema_spec.rb
@@ -51,8 +51,13 @@ describe 'Pedicel::Validator::TokenDataPaymentDataSchema' do
       is_expected.to satisfy_schema(tdpds)
     end
 
+    it 'must be filled when present' do
+      token_data_payment_data_h[:eciIndicator] = ''
+      is_expected.to dissatisfy_schema(tdpds, eciIndicator: ['must be filled'])
+    end
+
     it 'errs when invalid' do
-      %w[1 123 1A].each do |invalid_value|
+      ['123', '1A'].each do |invalid_value|
         token_data_payment_data_h[:eciIndicator] = invalid_value
 
         is_expected.to dissatisfy_schema(tdpds, eciIndicator: ['must be an ECI'])


### PR DESCRIPTION
Even though the document "3-D Secure Protocol Specification Core Functions Version 1.0.2" specifies "Length: 0 or 2 characters" for the ECI, we have observed single digit ECIs in production for valid authorisations.