### PR TITLE
Loosen up Ruby version requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5]
+        ruby: [2.5, 2.7]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'dry-validation', '~> 0.11.1'
 
-  s.required_ruby_version = '~> 2.5.5'
+  s.required_ruby_version = '>= 2.5.5'
 
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.7'


### PR DESCRIPTION
Debian Bullseye uses Ruby 2.7, so this needs updated Ruby version requirements to be compatible. Loosening up the Ruby version requirement seems like the simplest way of adding support for Ruby 2.7 without sacrificing support for 2.5.5.