### PR TITLE
Upgrade GitHub Actions to use `ruby/setup-ruby@v1`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,22 @@
 name: Test
 on:
   - push
+  - pull_request
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ruby: [2.5]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
 
-    - name: Install Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.5
-
     - name: Run tests
-      id: run-tests
-      run: |
-        bundle install
-        bundle exec rake test
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake
+    - run: bundle exec rake test


### PR DESCRIPTION
GitHub Actions has broken as https://github.com/actions/setup-ruby has been deprecated in favor of https://github.com/ruby/setup-ruby. This was discovered in https://github.com/clearhaus/pedicel/pull/33.

This replaces the old `actions/setup-ruby` with `ruby/setup-ruby` and adds Matrix testing. This is based on the example here: https://github.com/ruby/setup-ruby#matrix-of-ruby-versions.