### PR TITLE
Make ISO 4217 requirement more lax

### DIFF
--- a/lib/pedicel/validator.rb
+++ b/lib/pedicel/validator.rb
@@ -102,7 +102,7 @@ module Pedicel
 
     Dry::Validation.register_macro(:is_iso4217_numeric) do
       if key?
-        unless  /\A[0-9]{3}\z/.match?(value)
+        unless  /\A[0-9]{3}\z/.match?(value.rjust(3, "0"))
           key.failure(CUSTOM_ERRORS[:is_iso4217_numeric])
         end
       end

--- a/lib/pedicel/version.rb
+++ b/lib/pedicel/version.rb
@@ -1,3 +1,3 @@
 module Pedicel
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/lib/pedicel/validator/errors_formatted_spec.rb
+++ b/spec/lib/pedicel/validator/errors_formatted_spec.rb
@@ -22,7 +22,8 @@ describe 'Pedicel::Validator' do
   end
 
   it 'formats a bunch of errors as expected' do
-    invalid_data = valid_data.merge(currencyCode: '34')
+    # since https://github.com/clearhaus/issues-pci/issues/3415 a currencyCode of '34' technically legal
+    invalid_data = valid_data.merge(currencyCode: 'A34')
     invalid_data[:deviceManufacturerIdentifier] = 'g'
     invalid_data[:paymentData][:eciIndicator] = ''
 

--- a/spec/lib/pedicel/validator/token_data_schema_spec.rb
+++ b/spec/lib/pedicel/validator/token_data_schema_spec.rb
@@ -66,7 +66,7 @@ describe 'Pedicel::Validator::TokenDataSchema' do
     end
 
     it 'errs when currencyCode is not a currency code' do
-      %w[11 11A 1111].each do |invalid_value|
+      %w[A11 11A 1111].each do |invalid_value|
         token_data_h[:currencyCode] = invalid_value
         is_expected.to dissatisfy_schema(tds, currencyCode: ['must be an ISO 4217 numeric code'])
       end


### PR DESCRIPTION
Since apple don't include leading '0' in their tokens we have to pad the
currency code.

https://github.com/clearhaus/issues-pci/issues/3415