### PR TITLE
Fix dry-schema issue by pinning version 1.10.6

### DIFF
--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*.rb")
 
   s.add_runtime_dependency 'dry-validation', '1.8'
-  s.add_runtime_dependency 'dry-schema', '~> 1.9'
+  s.add_runtime_dependency 'dry-schema', '1.10.6'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 
   s.required_ruby_version = '~> 2.7.4'


### PR DESCRIPTION
This isn't optimal but it's a step in the right direction for fixing:

```
bundle exec rake test

An error occurred while loading ./spec/lib/pedicel/base_spec.rb.
Failure/Error: require 'dry/validation'

NameError:
  uninitialized constant Dry::Schema::PredicateRegistry
  
[...]

No examples found.

Finished in 0.00004 seconds (files took 0.18467 seconds to load)
0 examples, 0 failures, 10 errors occurred outside of examples

Error: Process completed with exit code 1.
```

The main reason for a quickfix is to get the bug fix https://github.com/clearhaus/pedicel/pull/37 released.

Feel free to improve :slightly_smiling_face: 