### PR TITLE
Bump dry-validation to 1.9

### DIFF
--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/**/*.rb")
 
-  s.add_runtime_dependency 'dry-validation', '1.8'
+  s.add_runtime_dependency 'dry-validation', '1.9'
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 


### PR DESCRIPTION
Older versions of dry-validation do not work with the introduction of zeitwerk in dry-schema 1.11.0.

See:

- https://github.com/dry-rb/dry-schema/blob/main/CHANGELOG.md#1110-2022-10-15
- https://github.com/dry-rb/dry-schema/issues/434#issuecomment-1279786509

This makes https://github.com/clearhaus/pedicel/pull/38 obsolete.