### PR TITLE
Bump pedicel version to 1.1.0

### DIFF
--- a/lib/pedicel/version.rb
+++ b/lib/pedicel/version.rb
@@ -1,3 +1,3 @@
 module Pedicel
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
To accommodate for an upcoming v1.1.0 release with this text:

- Make ISO 4217 requirement more lax.
- Bump dry-validation to 1.9.

I believe the first of the two deserves a minor version bump.