### PR TITLE
Add OpenSSL 3.0 and Ruby >= 2.7.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.7]
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         ruby:
           - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Check out repository
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run tests
       uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
 
-# dev dependency
-gem 'pedicel-pay', git: 'https://github.com/cub8/pedicel-pay', branch: 'openssl-30-support'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'pedicel-pay', path: '../pedicel-pay'
+# dev dependency
+gem 'pedicel-pay', git: 'https://github.com/cub8/pedicel-pay', branch: 'raise-gems-versions'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # dev dependency
-gem 'pedicel-pay', git: 'https://github.com/cub8/pedicel-pay', branch: 'raise-gems-versions'
+gem 'pedicel-pay', git: 'https://github.com/cub8/pedicel-pay', branch: 'openssl-30-support'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'pedicel-pay', path: '../pedicel-pay'
+
 gemspec

--- a/lib/pedicel/version.rb
+++ b/lib/pedicel/version.rb
@@ -1,3 +1,3 @@
 module Pedicel
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/**/*.rb")
 
-  s.add_runtime_dependency 'dry-validation', '1.9'
+  s.add_runtime_dependency 'dry-validation', '~> 1.9'
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 
-  # s.required_ruby_version = '~> 2.7.4'
+  s.required_ruby_version = '>= 2.7.4', '<= 3.2'
 
-  s.add_development_dependency 'pedicel-pay', '~> 0.0'
+  s.add_development_dependency 'pedicel-pay'
   s.add_development_dependency 'pry', '~> 0.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.7'

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 
-  s.required_ruby_version = '>= 2.7.4', '<= 3.2'
+  s.required_ruby_version = '>= 2.7.4'
 
   # s.add_development_dependency 'pedicel-pay'
   s.add_development_dependency 'pry', '~> 0.0'

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7.4'
 
-  # s.add_development_dependency 'pedicel-pay'
+  s.add_development_dependency 'pedicel-pay', '~> 0.0.8'
   s.add_development_dependency 'pry', '~> 0.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.7'

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 
-  s.required_ruby_version = '~> 2.7.4'
+  # s.required_ruby_version = '~> 2.7.4'
 
-  s.add_development_dependency 'rake', '~> 12.3'
-  s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'pedicel-pay', '~> 0.0'
   s.add_development_dependency 'pry', '~> 0.0'
+  s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency 'rspec', '~> 3.7'
 end

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7.4', '<= 3.2'
 
-  s.add_development_dependency 'pedicel-pay'
+  # s.add_development_dependency 'pedicel-pay'
   s.add_development_dependency 'pry', '~> 0.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rspec', '~> 3.7'

--- a/pedicel.gemspec
+++ b/pedicel.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*.rb")
 
   s.add_runtime_dependency 'dry-validation', '~> 1.9'
+  s.add_runtime_dependency 'dry-core', '1.0.0'
   s.add_runtime_dependency 'dry-schema', '~> 1.9'
   s.add_runtime_dependency 'dry-logic', '~> 1.0'
 

--- a/spec/lib/pedicel/base_spec.rb
+++ b/spec/lib/pedicel/base_spec.rb
@@ -233,8 +233,7 @@ describe 'Pedicel::Base' do
 
       it 'handles that one certificate can be both intermediate and leaf' do
         def create_special_certificate(ca_key, ca_certificate, config, oids)
-          key = OpenSSL::PKey::EC.new(PedicelPay::EC_CURVE)
-          key.generate_key
+          key = OpenSSL::PKey::EC.generate(PedicelPay::EC_CURVE)
 
           cert = OpenSSL::X509::Certificate.new
           # https://www.ietf.org/rfc/rfc5280.txt -> Section 4.1, search for "v3(2)".
@@ -242,7 +241,7 @@ describe 'Pedicel::Base' do
           cert.serial = 1
           cert.subject = config[:subject][:intermediate]
           cert.issuer = ca_certificate.subject
-          cert.public_key = PedicelPay::Helper.ec_key_to_pkey_public_key(key)
+          cert.public_key = key # PedicelPay::Helper.ec_key_to_pkey_public_key(key)
           cert.not_before = config[:valid].min
           cert.not_after = config[:valid].max
 

--- a/spec/lib/pedicel/base_spec.rb
+++ b/spec/lib/pedicel/base_spec.rb
@@ -241,7 +241,7 @@ describe 'Pedicel::Base' do
           cert.serial = 1
           cert.subject = config[:subject][:intermediate]
           cert.issuer = ca_certificate.subject
-          cert.public_key = key # PedicelPay::Helper.ec_key_to_pkey_public_key(key)
+          cert.public_key = key
           cert.not_before = config[:valid].min
           cert.not_after = config[:valid].max
 

--- a/spec/lib/pedicel/base_spec.rb
+++ b/spec/lib/pedicel/base_spec.rb
@@ -356,81 +356,81 @@ describe 'Pedicel::Base' do
     end
 
     it 'does not err when the chain is good' do
-      expect{Pedicel::Base.verify_x509_chain(params)}.to_not raise_error
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to_not raise_error
     end
 
     context 'intermediate equals leaf' do
       it 'errs if intermediate = leaf (because root did not sign leaf)' do
         params[:intermediate] = params[:leaf]
-        expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
+        expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
       end
 
       it 'errs even if intermediate = leaf is self-signed' do
         params[:intermediate] = params[:leaf] = PedicelPay::Backend.generate.ca_certificate
-        expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
+        expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
       end
     end
 
     context 'leaf equals intermediate' do
       it 'errs if leaf = intermediate (because intermediate did not sign leaf)' do
         params[:leaf] = params[:intermediate]
-        expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+        expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
       end
 
       it 'errs even if leaf = intermediate is self-signed' do
         params[:leaf] = params[:intermediate] = PedicelPay::Backend.generate.ca_certificate
-        expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
+        expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
       end
     end
 
     it 'errs if intermediate equals root (because root did not sign leaf)' do
       params[:intermediate] = params[:root]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
     end
 
     it 'errs if root equals intermediate (because intermediate is not self-signed)' do
       params[:root] = params[:intermediate]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
     end
 
     it 'errs if leaf equals root (because intermediate did not sign leaf)' do
       params[:leaf] = params[:root]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
     end
 
     it 'errs if root equals leaf (becuase leaf is not self-signed)' do
       params[:root] = params[:leaf]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
     end
 
     it 'errs if leaf is used for all 3 certificates (because of multiple reasons)' do
       params[:root]         = params[:leaf]
       params[:intermediate] = params[:leaf]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
     end
 
     it 'errs if intermediate is used for all 3 certificates' do
       params[:root] = params[:intermediate]
       params[:leaf] = params[:intermediate]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to root')
     end
 
     it 'does not err when root is used for all 3 certificates' do
       params[:intermediate] = params[:root]
       params[:leaf]         = params[:root]
-      expect{Pedicel::Base.verify_x509_chain(params)}.to_not raise_error
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to_not raise_error
     end
 
     it 'errs if intermediate is not signed by root' do
       params[:root] = PedicelPay::Backend.generate.ca_certificate
 
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
     end
 
     it 'errs if leaf is not signed by intermediate (1)' do
       params[:leaf] = PedicelPay::Backend.generate.leaf_certificate
 
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
     end
 
     it 'errs if leaf is not signed by intermediate (2)' do
@@ -438,34 +438,33 @@ describe 'Pedicel::Base' do
       params[:root]         = another_backend.ca_certificate
       params[:intermediate] = another_backend.intermediate_certificate
 
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
     end
 
     it 'errs if leaf is not signed by intermediate and intermediate is not signed by root' do
       params[:root]         = PedicelPay::Backend.generate.ca_certificate
       params[:intermediate] = PedicelPay::Backend.generate.intermediate_certificate
 
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to intermediate')
     end
 
     it 'errs if certs are interchanged' do
       params.keys.permutation.reject{|ks| ks == params.keys}.each do |permutated_keys|
         permutated_params = permutated_keys.zip(params.values).to_h
 
-        expect{Pedicel::Base.verify_x509_chain(permutated_params)}.to raise_error(Pedicel::SignatureError, /\Ainvalid chain due to (root|intermediate|leaf)\z/)
+        expect{Pedicel::Base.verify_x509_chain(**permutated_params)}.to raise_error(Pedicel::SignatureError, /\Ainvalid chain due to (root|intermediate|leaf)\z/)
       end
     end
 
     it 'errs even if the leaf is self-signed' do
       params[:leaf] = PedicelPay::Backend.generate.ca_certificate
-      expect{Pedicel::Base.verify_x509_chain(params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
+      expect{Pedicel::Base.verify_x509_chain(**params)}.to raise_error(Pedicel::SignatureError, 'invalid chain due to leaf')
     end
 
     it 'is true when the chain is good' do
-      expect(Pedicel::Base.verify_x509_chain(params)).to be true
+      expect(Pedicel::Base.verify_x509_chain(**params)).to be true
     end
   end
-
 
   describe 'Pedicel::Base.verify_signed_time' do
     let (:signature) { OpenSSL::PKCS7.new(pedicel.signature) }

--- a/spec/lib/pedicel/base_spec.rb
+++ b/spec/lib/pedicel/base_spec.rb
@@ -105,37 +105,37 @@ describe 'Pedicel::Base' do
       subject { lambda { pedicel.verify_signature } }
 
       it 'does not err when all checks are good' do
-        is_expected.to_not raise_error
+        expect { subject.call }.to_not raise_error
       end
 
       it 'checks for the custom OIDs (1.a)' do
         expect(Pedicel::Base).to receive(:extract_certificates).and_raise(Pedicel::SignatureError, 'boom')
 
-        is_expected.to raise_error(Pedicel::SignatureError, 'boom')
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, 'boom')
       end
 
       it 'checks that the root certificate is trusted (1.b)' do
         expect(Pedicel::Base).to receive(:verify_root_certificate).and_raise(Pedicel::SignatureError, 'boom')
 
-        is_expected.to raise_error(Pedicel::SignatureError, 'boom')
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, 'boom')
       end
 
       it 'checks the chain (1.c)' do
         expect(Pedicel::Base).to receive(:verify_x509_chain).and_raise(Pedicel::SignatureError, 'boom')
 
-        is_expected.to raise_error(Pedicel::SignatureError, 'boom')
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, 'boom')
       end
 
       it "checks the token's signature (1.d)" do
         expect(pedicel).to receive(:validate_signature).and_raise(Pedicel::SignatureError, 'boom')
 
-        is_expected.to raise_error(Pedicel::SignatureError, 'boom')
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, 'boom')
       end
 
       it 'checks signing time (1.e)' do
         expect(Pedicel::Base).to receive(:verify_signed_time).and_raise(Pedicel::SignatureError, 'boom')
 
-        is_expected.to raise_error(Pedicel::SignatureError, 'boom')
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, 'boom')
       end
     end
 
@@ -197,26 +197,26 @@ describe 'Pedicel::Base' do
       end
 
       it 'does not err when all checks are good' do
-        is_expected.to_not raise_error
+        expect { subject.call }.to_not raise_error
       end
 
       it 'errs if there is no leaf OID' do
         pedicel.config.merge!(oid_leaf_certificate: 'invalid oid')
 
-        is_expected.to raise_error(Pedicel::SignatureError, /no.*leaf.*found/)
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, /no.*leaf.*found/)
       end
 
       it 'errs if there is no intermediate OID' do
         pedicel.config.merge!(oid_intermediate_certificate: 'invalid oid')
 
-        is_expected.to raise_error(Pedicel::SignatureError, /no.*intermediate.*found/)
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, /no.*intermediate.*found/)
       end
 
       it 'errs if there are neither a leaf nor an intermediate OID' do
         pedicel.config.merge!(oid_leaf_certificate: 'invalid oid')
         pedicel.config.merge!(oid_intermediate_certificate: 'invalid oid')
 
-        is_expected.to raise_error(Pedicel::SignatureError, /no.*(leaf|intermediate).*found/)
+        expect { subject.call }.to raise_error(Pedicel::SignatureError, /no.*(leaf|intermediate).*found/)
       end
     end
 

--- a/spec/lib/pedicel/ec_spec.rb
+++ b/spec/lib/pedicel/ec_spec.rb
@@ -180,8 +180,7 @@ describe 'Pedicel::EC' do
     end
 
     it "errs if the private key is from another curve than the token's ephemeral public key" do
-      key = OpenSSL::PKey::EC.new('wap-wsg-idm-ecid-wtls1') # Apple, do never switch to this curve.
-      key.generate_key
+      key = OpenSSL::PKey::EC.generate('wap-wsg-idm-ecid-wtls1') # Apple, do never switch to this curve.
 
       expect{pedicel.shared_secret(private_key: key)}.to raise_error(Pedicel::EcKeyError, /curve.*differ/)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,2 @@
 require 'securerandom'
 require 'base64'
-
-def ec_key_to_pkey_public_key(ec_key)
-  # EC#public_key is not a PKey public key, but an EC point.
-  pub = OpenSSL::PKey::EC.new(ec_key.group)
-  pub.public_key = ec_key.is_a?(OpenSSL::PKey::PKey) ? ec_key.public_key : ec_key
-
-  pub
-end


### PR DESCRIPTION
Hi, this PR makes this gem functional Ruby >= 2.7.4 by changing required Ruby version from `~> 2.7.4` to `>= 2.7.4`. It also fixes tests to make them support Ruby >= 3.0 and OpenSSL >= 3.0.

Dependencies temporarily point at my fork of pedicel-pay gem. This should be changed after my PR in pedicel-pay will be accepted.

This PR is related to another [PR](https://github.com/clearhaus/pedicel-pay/pull/16) in pedicel-pay gem repo.