### PR TITLE
Add catalog-info.yaml for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pedicel
+  description: Apple Pay token handler/decrypter
+  tags:
+    - confidentiality:public
+    - integrity:integrity-and-authenticity-critical
+    - availability:real-time-critical
+    - pci-dss:yes
+spec:
+  type: library
+  lifecycle: production
+  owner: AEP
+  system: clearhaus


### PR DESCRIPTION
Issue: https://github.com/clearhaus/issues-pci/issues/5322

Integrity, availability and PCI DSS have deliberately been set to the same values as we have for the production service using the library.